### PR TITLE
(zsh) Add ~/.local/bin to $PATH

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -8,3 +8,5 @@ fi
 
 # load grml config
 . ~/.zsh/grml.zsh
+
+export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
pipx "made" me do this, but I guess this should be a normal practice for other package managers as well