### PR TITLE
(zsh) Make zshrc useful

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -9,4 +9,18 @@ fi
 # load grml config
 . ~/.zsh/grml.zsh
 
-export PATH=$HOME/.local/bin:$PATH
+# "main" function, because I do want my local variables to stay local
+function () {
+    # some variables
+    local DOTFILES="$HOME/.config/dotfiles"
+    local SHELL_RC="$HOME/.zshrc"
+    export EDITOR="nvim"
+
+    # better path
+    export PATH=$HOME/.local/bin:$PATH
+
+    # aliases
+    alias cddot="cd $DOTFILES"
+    alias upd="source $SHELL_RC"
+    alias edsh="$EDITOR $SHELL_RC"
+}


### PR DESCRIPTION
- Add `cddot` alias to travel to dotfiles
- Add `upd` alias to re-source zshrc
- Add `edsh` alias to edit zshrc

also, neat trick with "scopes" in zsh, if you create function without a name in zsh, it will create a functional scope, where you can create local variables which will actually stay local and vanish after the "function" ends. Also it's called automatically, yeah, just like IIFE in JavaScript.