### PR TITLE
Add alias python=python3

### DIFF
--- a/shells/zsh/zshrc
+++ b/shells/zsh/zshrc
@@ -1,7 +1,7 @@
 # download grml config if doesn't exist
 if [ ! -f ~/.zsh/grml.zsh ]; then
-    echo "grml configuration not found"
-    echo "installing grml zsh configuration"
+    echo "<> grml configuration not found"
+    echo "<> installing grml zsh configuration"
     curl -L https://git.grml.org/f/grml-etc-core/etc/zsh/zshrc --create-dirs -o ~/.zsh/grml.zsh
 fi
 
@@ -16,6 +16,8 @@ then
     # two-line prompt with git integration
     # download if needed
     if [ ! -d ~/.zsh/agkozak-zsh-prompt ]; then
+        echo "<> agkozak prompt not found"
+        echo "<> loading agkozak zsh prompt"
         git clone https://github.com/agkozak/agkozak-zsh-prompt \
             "$HOME/.zsh/agkozak-zsh-prompt"
     fi
@@ -59,4 +61,17 @@ function () {
     alias upd="source $SHELL_RC"
     alias edsh="$EDITOR $SHELL_RC"
     alias edvim="$EDITOR $VIM_RC"
+
+    # if has python3
+    which python3 > /dev/null
+    local ok_python3=$?
+    if (( $ok_python3 == 0 )); then
+        which python > /dev/null
+        local ok_python=$?
+        # but doesn't have python command
+        if (( $ok_python != 0 )); then
+            # just add the alias, for the love of god
+            alias python="python3"
+        fi
+    fi
 }


### PR DESCRIPTION
If finds python3, but can't find python, make an alias. I mean, ideally that would been a package on all available systems like python-is-python3 on Ubuntu, or just give me python as python3, python2 was deprecated like ten years ago if not more.

But yeah, alias it is.

I also added some pretty loading messages when first starting zsh and it attempts to load grml configuration and agkozak prompt.